### PR TITLE
allow command to be positional

### DIFF
--- a/unjailbox
+++ b/unjailbox
@@ -3,7 +3,6 @@
 source /etc/jailbox/config
 USAGE="Run command without tor.\nUsage: $(basename $0) [-hv] [-u user] [-c command]"
 USER="$(/usr/bin/logname)"
-CMD="bash"
 
 # parse command line arguments
 while getopts "hvu:c:" opt; do
@@ -30,6 +29,8 @@ if [ $UID -ne 0 ]; then
   echo "Superuser rights required" >&2
   exit 2
 fi
+
+CMD="${CMD:-${@:-sh}}
 
 # run command in isolated namespace
 ip netns exec "${namespace}" su -c "${CMD}" "${USER}"


### PR DESCRIPTION
Using this patch one can still use optional argument -c, or just pass the command as positional arguments:

`unjailbox -u user -c "firefox --new-instance -P clearnet"`
same as :
`unjailbox -u user firefox --new-instance -P clearnet`